### PR TITLE
Twirperrors

### DIFF
--- a/errorstest/adapter.go
+++ b/errorstest/adapter.go
@@ -2,7 +2,6 @@ package errorstest
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	errors "github.com/segmentio/errors-go"
@@ -31,13 +30,13 @@ func TestAdapter(t *testing.T, a errors.Adapter, tests ...AdapterTest) {
 				}
 			}
 
-			if types := errors.Types(err); !reflect.DeepEqual(types, test.Types) {
+			if types := errors.Types(err); !typesEqual(types, test.Types) {
 				t.Error("types mismatch")
 				t.Log("expected:", test.Types)
 				t.Log("found:   ", types)
 			}
 
-			if tags := errors.Tags(err); !reflect.DeepEqual(tags, test.Tags) {
+			if tags := errors.Tags(err); !tagsEqual(tags, test.Tags) {
 				t.Error("tags mismatch")
 				t.Log("expected:", test.Tags)
 				t.Log("found:   ", tags)
@@ -78,4 +77,28 @@ func message(err error) string {
 		return e.Message()
 	}
 	return ""
+}
+
+func typesEqual(t1, t2 []string) bool {
+	if len(t1) != len(t2) {
+		return false
+	}
+	for i := range t1 {
+		if t1[i] != t2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func tagsEqual(t1, t2 []errors.Tag) bool {
+	if len(t1) != len(t2) {
+		return false
+	}
+	for i := range t1 {
+		if t1[i] != t2[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/neterrors/adapter_test.go
+++ b/neterrors/adapter_test.go
@@ -53,7 +53,7 @@ func TestAdapt(t *testing.T) {
 
 		errorstest.AdapterTest{
 			Error: &net.DNSError{IsTimeout: true},
-			Types: []string{"Timeout", "Unreachable"},
+			Types: []string{"Temporary", "Timeout", "Unreachable"},
 		},
 
 		errorstest.AdapterTest{

--- a/twirperrors/adapter.go
+++ b/twirperrors/adapter.go
@@ -1,0 +1,93 @@
+package twirperrors
+
+import (
+	errors "github.com/segmentio/errors-go"
+	"github.com/twitchtv/twirp"
+)
+
+func Adapt(err error) (error, bool) {
+	if e, ok := err.(twirp.Error); ok {
+		return &twirpError{cause: e}, true
+	}
+	return err, false
+}
+
+type twirpError struct {
+	cause twirp.Error
+}
+
+func (e *twirpError) Cause() error { return e.cause }
+
+func (e *twirpError) Error() string { return e.cause.Error() }
+
+func (e *twirpError) Message() string { return e.cause.Msg() }
+
+func (e *twirpError) Tags() []errors.Tag {
+	meta := e.cause.MetaMap()
+	tags := make([]errors.Tag, 0, len(meta))
+
+	for name, value := range meta {
+		tags = append(tags, errors.Tag{
+			Name:  name,
+			Value: value,
+		})
+	}
+
+	return tags
+}
+
+// Twirp-specific error types
+
+func (e *twirpError) Canceled() bool { return e.is(twirp.Canceled) }
+
+func (e *twirpError) Unknown() bool { return e.is(twirp.Unknown) }
+
+func (e *twirpError) InvalidArgument() bool { return e.is(twirp.InvalidArgument) }
+
+func (e *twirpError) DeadlineExceeded() bool { return e.is(twirp.DeadlineExceeded) }
+
+func (e *twirpError) NotFound() bool { return e.is(twirp.NotFound) }
+
+func (e *twirpError) BadRoute() bool { return e.is(twirp.BadRoute) }
+
+func (e *twirpError) AlreadyExists() bool { return e.is(twirp.AlreadyExists) }
+
+func (e *twirpError) PermissionDenied() bool { return e.is(twirp.PermissionDenied) }
+
+func (e *twirpError) Unauthenticated() bool { return e.is(twirp.Unauthenticated) }
+
+func (e *twirpError) ResourceExhausted() bool { return e.is(twirp.ResourceExhausted) }
+
+func (e *twirpError) FailedPrecondition() bool { return e.is(twirp.FailedPrecondition) }
+
+func (e *twirpError) Aborted() bool { return e.is(twirp.Aborted) }
+
+func (e *twirpError) OutOfRange() bool { return e.is(twirp.OutOfRange) }
+
+func (e *twirpError) Unimplemented() bool { return e.is(twirp.Unimplemented) }
+
+func (e *twirpError) Internal() bool { return e.is(twirp.Internal) }
+
+func (e *twirpError) Unavailable() bool { return e.is(twirp.Unavailable) }
+
+func (e *twirpError) DataLoss() bool { return e.is(twirp.DataLoss) }
+
+func (e *twirpError) is(code twirp.ErrorCode) bool { return e.cause.Code() == code }
+
+// Common error types
+
+func (e *twirpError) Conflict() bool { return e.AlreadyExists() }
+
+func (e *twirpError) Throttled() bool { return e.ResourceExhausted() }
+
+func (e *twirpError) Timeout() bool { return e.Canceled() || e.DeadlineExceeded() }
+
+func (e *twirpError) Validation() bool { return e.InvalidArgument() || e.OutOfRange() || e.BadRoute() }
+
+func (e *twirpError) Temporary() bool {
+	return e.Timeout() ||
+		e.Throttled() ||
+		e.Unimplemented() ||
+		e.Internal() ||
+		e.Unavailable()
+}

--- a/twirperrors/adapter.go
+++ b/twirperrors/adapter.go
@@ -5,6 +5,12 @@ import (
 	"github.com/twitchtv/twirp"
 )
 
+// Adapt checks the type of err is a twirp error, and adapts it to make error
+// types discoverable using the errors.Is function.
+//
+// This function is automatically installed as a global adapter when importing
+// the neterrors package, a program likely should use errors.Adapt instead of
+// calling this adapter directly.
 func Adapt(err error) (error, bool) {
 	if e, ok := err.(twirp.Error); ok {
 		return &twirpError{cause: e}, true

--- a/twirperrors/adapter_test.go
+++ b/twirperrors/adapter_test.go
@@ -1,0 +1,113 @@
+package twirperrors
+
+import (
+	"testing"
+
+	errors "github.com/segmentio/errors-go"
+	"github.com/segmentio/errors-go/errorstest"
+	"github.com/twitchtv/twirp"
+)
+
+func TestAdapt(t *testing.T) {
+	errorstest.TestAdapter(t, errors.AdapterFunc(Adapt),
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Canceled, ""),
+			Types: []string{"Canceled", "Temporary", "Timeout"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Unknown, ""),
+			Types: []string{"Unknown"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.InvalidArgument, ""),
+			Types: []string{"InvalidArgument", "Validation"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.DeadlineExceeded, ""),
+			Types: []string{"DeadlineExceeded", "Temporary", "Timeout"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.NotFound, ""),
+			Types: []string{"NotFound"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.BadRoute, ""),
+			Types: []string{"BadRoute", "Validation"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.AlreadyExists, ""),
+			Types: []string{"AlreadyExists", "Conflict"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.PermissionDenied, ""),
+			Types: []string{"PermissionDenied"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Unauthenticated, ""),
+			Types: []string{"Unauthenticated"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.ResourceExhausted, ""),
+			Types: []string{"ResourceExhausted", "Temporary", "Throttled"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.FailedPrecondition, ""),
+			Types: []string{"FailedPrecondition"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Aborted, ""),
+			Types: []string{"Aborted"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.OutOfRange, ""),
+			Types: []string{"OutOfRange", "Validation"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Unimplemented, ""),
+			Types: []string{"Temporary", "Unimplemented"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Internal, ""),
+			Types: []string{"Internal", "Temporary"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.Unavailable, ""),
+			Types: []string{"Temporary", "Unavailable"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.DataLoss, ""),
+			Types: []string{"DataLoss"},
+		},
+
+		errorstest.AdapterTest{
+			Error: twirp.NewError(twirp.NotFound, "").WithMeta("hello", "world").WithMeta("twitch", "tv"),
+			Types: []string{"NotFound"},
+			Tags: []errors.Tag{
+				{Name: "hello", Value: "world"},
+				{Name: "twitch", Value: "tv"},
+			},
+		},
+
+		errorstest.AdapterTest{
+			Error:   twirp.NewError(twirp.NotFound, "hello world!"),
+			Message: "hello world!",
+			Types:   []string{"NotFound"},
+		},
+	)
+}

--- a/twirperrors/doc.go
+++ b/twirperrors/doc.go
@@ -1,0 +1,7 @@
+// Package twirperrors provides functions to adapt errors of the
+// github.com/twitchtv/twirp package into errors compatible with the errors-go
+// package.
+//
+// Importing this package installs the aws errors adapters on the global set of
+// adapters of the parent errors-go package.
+package twirperrors

--- a/twirperrors/errors.go
+++ b/twirperrors/errors.go
@@ -20,7 +20,7 @@ func New(err error) twirp.Error {
 	msgs, types, tags, _, _ := errors.Inspect(err)
 
 	for _, typ := range types {
-		switch code := twirp.ErrorCode(typ); code {
+		switch typ {
 		case "Canceled":
 			return newError(twirp.Canceled, msgs, tags)
 
@@ -71,6 +71,22 @@ func New(err error) twirp.Error {
 
 		case "DataLoss":
 			return newError(twirp.DataLoss, msgs, tags)
+		}
+	}
+
+	for _, typ := range types {
+		switch typ {
+		case "Validation":
+			return newError(twirp.InvalidArgument, msgs, tags)
+
+		case "Timeout":
+			return newError(twirp.DeadlineExceeded, msgs, tags)
+
+		case "Throttled":
+			return newError(twirp.ResourceExhausted, msgs, tags)
+
+		case "Conflict":
+			return newError(twirp.AlreadyExists, msgs, tags)
 		}
 	}
 

--- a/twirperrors/errors.go
+++ b/twirperrors/errors.go
@@ -1,0 +1,86 @@
+package twirperrors
+
+import (
+	"strings"
+
+	errors "github.com/segmentio/errors-go"
+	"github.com/twitchtv/twirp"
+)
+
+// New constructs a twirp error from another error. The error code is guessed by
+// inspecting the types of err, and defaults to twirp.Unknown if the error had
+// no types.
+//
+// If err is nil the function returns nil.
+func New(err error) twirp.Error {
+	if err == nil {
+		return nil
+	}
+
+	msgs, types, tags, _, _ := errors.Inspect(err)
+
+	for _, typ := range types {
+		switch code := twirp.ErrorCode(typ); code {
+		case "Canceled":
+			return newError(twirp.Canceled, msgs, tags)
+
+		case "Unknown":
+			return newError(twirp.Unknown, msgs, tags)
+
+		case "InvalidArgument":
+			return newError(twirp.InvalidArgument, msgs, tags)
+
+		case "DeadlineExceeded":
+			return newError(twirp.DeadlineExceeded, msgs, tags)
+
+		case "NotFound":
+			return newError(twirp.NotFound, msgs, tags)
+
+		case "BadRoute":
+			return newError(twirp.BadRoute, msgs, tags)
+
+		case "AlreadyExists":
+			return newError(twirp.AlreadyExists, msgs, tags)
+
+		case "PermissionDenied":
+			return newError(twirp.PermissionDenied, msgs, tags)
+
+		case "Unauthenticated":
+			return newError(twirp.Unauthenticated, msgs, tags)
+
+		case "ResourceExhausted":
+			return newError(twirp.ResourceExhausted, msgs, tags)
+
+		case "FailedPrecondition":
+			return newError(twirp.FailedPrecondition, msgs, tags)
+
+		case "Aborted":
+			return newError(twirp.Aborted, msgs, tags)
+
+		case "OutOfRange":
+			return newError(twirp.OutOfRange, msgs, tags)
+
+		case "Unimplemented":
+			return newError(twirp.Unimplemented, msgs, tags)
+
+		case "Internal":
+			return newError(twirp.Internal, msgs, tags)
+
+		case "Unavailable":
+			return newError(twirp.Unavailable, msgs, tags)
+
+		case "DataLoss":
+			return newError(twirp.DataLoss, msgs, tags)
+		}
+	}
+
+	return newError(twirp.Unknown, msgs, tags)
+}
+
+func newError(code twirp.ErrorCode, msgs []string, tags []errors.Tag) twirp.Error {
+	twerr := twirp.NewError(code, strings.Join(msgs, ": "))
+	for _, tag := range tags {
+		twerr = twerr.WithMeta(tag.Name, tag.Value)
+	}
+	return twerr
+}

--- a/twirperrors/errors.go
+++ b/twirperrors/errors.go
@@ -17,6 +17,10 @@ func New(err error) twirp.Error {
 		return nil
 	}
 
+	if twerr, ok := err.(twirp.Error); ok {
+		return twerr
+	}
+
 	msgs, types, tags, _, _ := errors.Inspect(err)
 
 	for _, typ := range types {

--- a/twirperrors/errors_test.go
+++ b/twirperrors/errors_test.go
@@ -2,6 +2,7 @@ package twirperrors
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	errors "github.com/segmentio/errors-go"
@@ -99,6 +100,26 @@ func TestNew(t *testing.T) {
 		},
 
 		{
+			types: []string{"Validation"},
+			code:  twirp.InvalidArgument,
+		},
+
+		{
+			types: []string{"Timeout"},
+			code:  twirp.DeadlineExceeded,
+		},
+
+		{
+			types: []string{"Throttled"},
+			code:  twirp.ResourceExhausted,
+		},
+
+		{
+			types: []string{"Conflict"},
+			code:  twirp.AlreadyExists,
+		},
+
+		{
 			types: []string{"Whatever"},
 			code:  twirp.Unknown,
 		},
@@ -116,7 +137,7 @@ func TestNew(t *testing.T) {
 	})
 
 	for _, test := range tests {
-		t.Run(string(test.code), func(t *testing.T) {
+		t.Run(strings.Join(test.types, ","), func(t *testing.T) {
 			twerr := New(
 				errors.WithTags(
 					errors.WithTypes(errors.New("oops"), test.types...),

--- a/twirperrors/errors_test.go
+++ b/twirperrors/errors_test.go
@@ -1,0 +1,144 @@
+package twirperrors
+
+import (
+	"reflect"
+	"testing"
+
+	errors "github.com/segmentio/errors-go"
+	"github.com/twitchtv/twirp"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		types []string
+		code  twirp.ErrorCode
+	}{
+		{
+			types: []string{"Canceled"},
+			code:  twirp.Canceled,
+		},
+
+		{
+			types: []string{"Unknown"},
+			code:  twirp.Unknown,
+		},
+
+		{
+			types: []string{"InvalidArgument"},
+			code:  twirp.InvalidArgument,
+		},
+
+		{
+			types: []string{"DeadlineExceeded"},
+			code:  twirp.DeadlineExceeded,
+		},
+
+		{
+			types: []string{"NotFound"},
+			code:  twirp.NotFound,
+		},
+
+		{
+			types: []string{"BadRoute"},
+			code:  twirp.BadRoute,
+		},
+
+		{
+			types: []string{"AlreadyExists"},
+			code:  twirp.AlreadyExists,
+		},
+
+		{
+			types: []string{"PermissionDenied"},
+			code:  twirp.PermissionDenied,
+		},
+
+		{
+			types: []string{"Unauthenticated"},
+			code:  twirp.Unauthenticated,
+		},
+
+		{
+			types: []string{"ResourceExhausted"},
+			code:  twirp.ResourceExhausted,
+		},
+
+		{
+			types: []string{"FailedPrecondition"},
+			code:  twirp.FailedPrecondition,
+		},
+
+		{
+			types: []string{"Aborted"},
+			code:  twirp.Aborted,
+		},
+
+		{
+			types: []string{"OutOfRange"},
+			code:  twirp.OutOfRange,
+		},
+
+		{
+			types: []string{"Unimplemented"},
+			code:  twirp.Unimplemented,
+		},
+
+		{
+			types: []string{"Internal"},
+			code:  twirp.Internal,
+		},
+
+		{
+			types: []string{"Unavailable"},
+			code:  twirp.Unavailable,
+		},
+
+		{
+			types: []string{"DataLoss"},
+			code:  twirp.DataLoss,
+		},
+
+		{
+			types: []string{"Whatever"},
+			code:  twirp.Unknown,
+		},
+
+		{
+			types: []string{},
+			code:  twirp.Unknown,
+		},
+	}
+
+	t.Run("<nil>", func(t *testing.T) {
+		if twerr := New(nil); twerr != nil {
+			t.Error("calling New on a nil error did not return a nil error")
+		}
+	})
+
+	for _, test := range tests {
+		t.Run(string(test.code), func(t *testing.T) {
+			twerr := New(
+				errors.WithTags(
+					errors.WithTypes(errors.New("oops"), test.types...),
+					errors.T("hello", "world"),
+					errors.T("twitch", "tv"),
+				),
+			)
+
+			if msg := twerr.Msg(); msg != "oops" {
+				t.Error("wrong error message:", msg)
+			}
+
+			if code := twerr.Code(); code != test.code {
+				t.Error("wrong error code:", code)
+			}
+
+			if meta := twerr.MetaMap(); !reflect.DeepEqual(meta, map[string]string{
+				"hello":  "world",
+				"twitch": "tv",
+			}) {
+				t.Error("wrong meta map:", meta)
+			}
+		})
+	}
+}

--- a/twirperrors/errors_test.go
+++ b/twirperrors/errors_test.go
@@ -136,6 +136,15 @@ func TestNew(t *testing.T) {
 		}
 	})
 
+	t.Run("twirp.Error", func(t *testing.T) {
+		twerr1 := twirp.NewError(twirp.Canceled, "")
+		twerr2 := New(twerr1)
+
+		if twerr1 != twerr2 {
+			t.Error("callign New on a twirp.Error did not return the same error")
+		}
+	})
+
 	for _, test := range tests {
 		t.Run(strings.Join(test.types, ","), func(t *testing.T) {
 			twerr := New(

--- a/twirperrors/init.go
+++ b/twirperrors/init.go
@@ -1,0 +1,7 @@
+package twirperrors
+
+import errors "github.com/segmentio/errors-go"
+
+func init() {
+	errors.Register(errors.AdapterFunc(Adapt))
+}


### PR DESCRIPTION
This PR adds adapters for [twirp](https://github.com/twitchtv/twirp) errors so we can introspect them using functions of the errors-go package.

See https://github.com/twitchtv/twirp/wiki/Errors for details about how error handling is done in twirp.

Please take a look and let me know if anything should be changed.