### PR TITLE
Fix small typos in the doc and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This allows the program to *ask questions* about the error value it received,
 like whether or not it's a temporary error, or if it happened because of a
 timeout (because the error type exposes `Temporary() bool` and `Timeout() bool`
 methods).
-This approach offers strong decoupling between components of a pgroam and is one
-of the pillar concepts that this package is built uppon.
+This approach offers strong decoupling between components of a program and is one
+of the pillar concepts that this package is built upon.
 
 Another limitation of carrying a single error value is that it doesn't allow
 layers of abstractions to add and carry context about the consequences of an
@@ -39,7 +39,7 @@ narrowed to solving a single aspect of error management.
 
 This is where the `errors-go` package comes into play. It is built to be a
 drop-in replacement for `pkg/errors` while offering a wider set of error
-mamangement tools that we wished we had countless times in order to build
+management tools that we wished we had countless times in order to build
 software that is more robust, expressive, and maintainable.
 
 ## Types
@@ -119,7 +119,7 @@ other attributes), a program can retrieve the original error by using the
 `errors.Cause(error) error` function. This mechanism is identical to what is
 done in the [`github.com/pkg/errors`](https://github.com/pkg/errors) package
 and is useful when a program needs to compare the original error value against
-some *contant* like `io.EOF` for example.
+some *constant* like `io.EOF` for example.
 
 However, it is common in Go to end up with more than one cause for an error.
 When a program spawns multiple goroutine to do I/O operations in parallel, some

--- a/adapter.go
+++ b/adapter.go
@@ -14,7 +14,7 @@ type Adapter interface {
 // makes it possible to use simple functions as error adapters.
 type AdapterFunc func(error) (error, bool)
 
-// Adapt satsifies the Adapter interface, calls f.
+// Adapt satisfies the Adapter interface, calls f.
 func (f AdapterFunc) Adapt(err error) (error, bool) { return f(err) }
 
 // Adapt adapts err using the registered adapters.

--- a/errors.go
+++ b/errors.go
@@ -300,7 +300,7 @@ func Causes(err error) []error {
 //
 // This model has been used in the standard library where some errors implement
 // the Temporary and Timeout methods to give the program more details about the
-// reason the error occured and the way it should be handled.
+// reason the error occurred and the way it should be handled.
 //
 // Here is an example of using the Is function:
 //


### PR DESCRIPTION
Hi!

Nice package!
The PR contains some fix for typos that I noticed while reading the README.
The other ones have been detected by the misspell tool.

Joseph
